### PR TITLE
Bug fixes and tweaks for a stronger baseline

### DIFF
--- a/configs/lf_disc_faster_rcnn_x101.yml
+++ b/configs/lf_disc_faster_rcnn_x101.yml
@@ -29,4 +29,10 @@ solver:
   num_epochs: 20
   initial_lr: 0.001
   training_splits: "train"  # "trainval"
-
+  lr_gamma: 0.1
+  lr_milestones: # epochs when lr —> lr * lr_gamma
+    - 3
+    - 5
+    - 7
+  warmup_factor: 0.2
+  warmup_epochs: 1

--- a/configs/lf_disc_faster_rcnn_x101.yml
+++ b/configs/lf_disc_faster_rcnn_x101.yml
@@ -27,12 +27,12 @@ model:
 solver:
   batch_size: 128 # 32 x num_gpus is a good rule of thumb
   num_epochs: 20
-  initial_lr: 0.001
+  initial_lr: 0.01
   training_splits: "train"  # "trainval"
   lr_gamma: 0.1
   lr_milestones: # epochs when lr —> lr * lr_gamma
-    - 3
-    - 5
+    - 4
     - 7
+    - 10
   warmup_factor: 0.2
   warmup_epochs: 1

--- a/configs/lf_disc_faster_rcnn_x101.yml
+++ b/configs/lf_disc_faster_rcnn_x101.yml
@@ -25,10 +25,8 @@ model:
 
 # Optimization related arguments
 solver:
-  batch_size: 32
+  batch_size: 128 # 32 x num_gpus is a good rule of thumb
   num_epochs: 20
   initial_lr: 0.001
-  lr_gamma: 0.9997592083
-  minimum_lr: 0.00005
   training_splits: "train"  # "trainval"
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -18,7 +18,7 @@ from visdialch.utils.checkpointing import load_checkpoint
 
 parser = argparse.ArgumentParser("Evaluate and/or generate EvalAI submission file.")
 parser.add_argument(
-    "--config-yml", default="configs/lf_disc_faster_rcnn_x101_bs32.yml",
+    "--config-yml", default="configs/lf_disc_faster_rcnn_x101.yml",
     help="Path to a config file listing reader, model and optimization parameters."
 )
 parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -225,6 +225,10 @@ for epoch in range(start_epoch, config["solver"]["num_epochs"] + 1):
 
     # Validate and report automatic metrics.
     if args.validate:
+
+        # switch dropout, batchnorm etc to the correct mode
+        model.eval()
+
         print(f"\nValidation after epoch {epoch}:")
         for i, batch in enumerate(tqdm(val_dataloader)):
             for key in batch:
@@ -243,4 +247,5 @@ for epoch in range(start_epoch, config["solver"]["num_epochs"] + 1):
             print(f"{metric_name}: {metric_value}")
         summary_writer.add_scalars("metrics", all_metrics, global_iteration_step)
 
+        model.train()
         torch.cuda.empty_cache()

--- a/train.py
+++ b/train.py
@@ -102,7 +102,7 @@ train_dataset = VisDialDataset(
     config["dataset"], args.train_json, overfit=args.overfit, in_memory=args.in_memory
 )
 train_dataloader = DataLoader(
-    train_dataset, batch_size=config["solver"]["batch_size"], num_workers=args.cpu_workers
+    train_dataset, batch_size=config["solver"]["batch_size"], num_workers=args.cpu_workers, shuffle=True
 )
 
 val_dataset = VisDialDataset(
@@ -189,9 +189,11 @@ for epoch in range(start_epoch, config["solver"]["num_epochs"] + 1):
 
         summary_writer.add_scalar("train/loss", batch_loss, global_iteration_step)
         summary_writer.add_scalar("train/lr", optimizer.param_groups[0]["lr"], global_iteration_step)
-        if optimizer.param_groups[0]["lr"] > config["solver"]["minimum_lr"]:
-            scheduler.step()
+
         global_iteration_step += 1
+        scheduler.step(global_iteration_step)
+
+        torch.cuda.empty_cache()
 
     # --------------------------------------------------------------------------------------------
     #   ON EPOCH END  (checkpointing and validation)
@@ -217,3 +219,5 @@ for epoch in range(start_epoch, config["solver"]["num_epochs"] + 1):
         for metric_name, metric_value in all_metrics.items():
             print(f"{metric_name}: {metric_value}")
         summary_writer.add_scalars("metrics", all_metrics, global_iteration_step)
+
+        torch.cuda.empty_cache()

--- a/visdialch/decoders/disc.py
+++ b/visdialch/decoders/disc.py
@@ -14,7 +14,9 @@ class DiscriminativeDecoder(nn.Module):
                                        padding_idx=vocabulary.PAD_INDEX)
         self.option_rnn = nn.LSTM(config["word_embedding_size"],
                                   config["lstm_hidden_size"],
-                                  batch_first=True)
+                                  config["lstm_num_layers"],
+                                  batch_first=True,
+                                  dropout=config["dropout"])
 
         # Options are variable length padded sequences, use DynamicRNN.
         self.option_rnn = DynamicRNN(self.option_rnn)


### PR DESCRIPTION
A few bug fixes and tweaks for a stronger baseline.

This improves MRR from 0.5845 to 0.6155 and NDCG from 0.5070 to 0.5315 on `val`.

Changes:

- Switched off dropout during evaluation on `val` in `train.py`.
- Shuffling batches during training (`shuffle=True` to `DataLoader`).
- Explicitly clearing GPU memory cache with `torch.cuda.empty_cache()`. Negligible time hit on single GPU, and fits batch sizes of up to 32 x no. of GPUs. There's some time gain when training with larger batch sizes.
- Added a linear learning rate warm up (https://arxiv.org/abs/1706.02677), followed by multi-step decaying.
- Using a multi-layer LSTM + dropout for the decoder.
- Switched from dot-product attention to a richer element-wise multiplication + fc layer attention. (The network can learn dot-product attention if it needs to.)

I've updated the config yaml. Will likely update with a trained model on `trainval` + numbers on `test-std` in 2-3 days.