### PR TITLE
Parallel tokenization and speedup during debugging.

### DIFF
--- a/train.py
+++ b/train.py
@@ -129,6 +129,7 @@ train_dataset = VisDialDataset(
     args.train_json,
     overfit=args.overfit,
     in_memory=args.in_memory,
+    num_workers=args.cpu_workers,
     return_options=True if config["model"]["decoder"] == "disc" else False,
     add_boundary_toks=False if config["model"]["decoder"] == "disc" else True,
 )
@@ -145,6 +146,7 @@ val_dataset = VisDialDataset(
     args.val_dense_json,
     overfit=args.overfit,
     in_memory=args.in_memory,
+    num_workers=args.cpu_workers,
     return_options=True,
     add_boundary_toks=False if config["model"]["decoder"] == "disc" else True,
 )

--- a/visdialch/data/dataset.py
+++ b/visdialch/data/dataset.py
@@ -27,6 +27,7 @@ class VisDialDataset(Dataset):
         dense_annotations_jsonpath: Optional[str] = None,
         overfit: bool = False,
         in_memory: bool = False,
+        num_workers: int = 1,
         return_options: bool = True,
         add_boundary_toks: bool = False,
     ):
@@ -34,7 +35,11 @@ class VisDialDataset(Dataset):
         self.config = config
         self.return_options = return_options
         self.add_boundary_toks = add_boundary_toks
-        self.dialogs_reader = DialogsReader(dialogs_jsonpath)
+        self.dialogs_reader = DialogsReader(
+            dialogs_jsonpath,
+            num_examples=(5 if overfit else None),
+            num_workers=num_workers
+        )
 
         if "val" in self.split and dense_annotations_jsonpath is not None:
             self.annotations_reader = DenseAnnotationsReader(

--- a/visdialch/data/readers.py
+++ b/visdialch/data/readers.py
@@ -53,16 +53,19 @@ class DialogsReader(object):
             # Maintain questions and answers as a dict instead of list because
             # they are referenced by index in dialogs. We drop elements from
             # these in "overfit" mode to save time (tokenization is slow).
-            # Add empty question, answer - useful for padding dialog rounds
-            # for test split.
             self.questions = {
                 i: question for i, question in
-                enumerate(visdial_data["data"]["questions"] + [""])
+                enumerate(visdial_data["data"]["questions"])
             }
             self.answers = {
                 i: answer for i, answer in
-                enumerate(visdial_data["data"]["answers"] + [""])
+                enumerate(visdial_data["data"]["answers"])
             }
+
+            # Add empty question, answer - useful for padding dialog rounds
+            # for test split.
+            self.questions[-1] = ""
+            self.answers[-1] = ""
 
             # ``image_id``` serves as key for all three dicts here.
             self.captions: Dict[int, Any] = {}
@@ -89,7 +92,8 @@ class DialogsReader(object):
                     _dialog["dialog"].append({"question": -1, "answer": -1})
 
                 # Add empty answer (and answer options) if not provided
-                # (for test split).
+                # (for test split). We use "-1" as a key for empty questions
+                # and answers.
                 for i in range(len(_dialog["dialog"])):
                     if "answer" not in _dialog["dialog"][i]:
                         _dialog["dialog"][i]["answer"] = -1


### PR DESCRIPTION
This PR introduces parallel tokenization in `DialogsReader`, and takes a stab at #13 . Key functionality:

1. When `--overfit` mode is specified, the reader drops the questions, answers and dialog examples which do not appear in first 5 examples of each VisDial split. This is handled by `num_examples` argument in `__init__` method. It is 5 if `--overfit` is specified, and `None` by default (don't drop any questions/answers).
   - This saves a lot of time in tokenization as most questions/answers are dropped:

![image](https://user-images.githubusercontent.com/10494087/61792747-0dd6df80-ae3b-11e9-9837-e10284eb2042.png)


2. Use `multiprocessing` module to parallelize tokenization of captions, questions, and answers. The number of processes is directly controlled by the `--cpu-workers` argument from the training script (also used by PyTorch dataloader).
   - Using 32 CPU workers we get up to tokenization speed of ~28000 sentences per second:

![image](https://user-images.githubusercontent.com/10494087/61792795-2cd57180-ae3b-11e9-8347-47bf3df12c1b.png)

   - As compared to ~6000 sentences per second without parallelization:

![image](https://user-images.githubusercontent.com/10494087/61793026-c2710100-ae3b-11e9-8e7f-9080ca8f2589.png)


CC: @shubhamagarwal92 @idansc @abhshkdz